### PR TITLE
Setting one pmem path on AppDirect mode may cause the pmem initialization path to be empty Path

### DIFF
--- a/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -190,7 +190,7 @@ private[spark] class BlockManager(
   val numNum = conf.getInt("spark.yarn.numa.num", 2)
 
   if (pmemMode.equals("AppDirect")) {
-    if (!isDriver && pmemInitialPaths.size > 1) {
+    if (!isDriver && pmemInitialPaths.size >= 1) {
       if (numaNodeId == -1) {
         numaNodeId = executorId.toInt
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)


## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

